### PR TITLE
Add open_libs tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The original template repository lives at [iamkaf/template-mod](https://github.c
 3. When bumping to a new Minecraft version, run `python scripts/set_minecraft_version.py <version>` to pull matching dependency versions.
 4. Replace the placeholder code in `TemplateMod` with your own logic.
 5. Run the Gradle `build` task to produce jars for each loader.
+6. After building, run `python scripts/open_libs.py <loader>` to open the
+   corresponding `build/libs` folder in your file explorer.
 
 ## Directory layout
 

--- a/scripts/open_libs.py
+++ b/scripts/open_libs.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Open the build/libs folder for a loader in the system file explorer."""
+
+import argparse
+import os
+import platform
+import subprocess
+from pathlib import Path
+
+
+def open_dir(path: Path) -> None:
+    """Open *path* in Explorer, Finder or the default file manager."""
+    system = platform.system()
+    if system == "Windows":
+        os.startfile(path)  # type: ignore[attr-defined]
+    elif system == "Darwin":
+        subprocess.run(["open", str(path)], check=False)
+    else:
+        subprocess.run(["xdg-open", str(path)], check=False)
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Open the build/libs folder for the given loader"
+    )
+    parser.add_argument(
+        "loader",
+        choices=["fabric", "forge", "neoforge"],
+        help="Loader to open the output for",
+    )
+    args = parser.parse_args(argv)
+    libs = Path(args.loader) / "build" / "libs"
+    if not libs.is_dir():
+        print(f"No libs folder found at {libs}. Run a build first.")
+        return
+    open_dir(libs)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `open_libs.py` helper to open build output directories in a file manager
- document script in README

## Testing
- `python -m py_compile scripts/open_libs.py`


------
https://chatgpt.com/codex/tasks/task_e_68601ab49a2c83319756f5933a49de47