### PR TITLE
Add Fabric datagen skeleton

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     //modImplementation "com.iamkaf.amber:amber-fabric:${amber_version}"
 }
 
+sourceSets.main.resources.srcDir('src/generated/resources')
+
 loom {
     def aw = project(':common').file("src/main/resources/${mod_id}.accesswidener")
     if (aw.exists()) {
@@ -37,6 +39,15 @@ loom {
             setConfigName('Fabric Server')
             ideConfigGenerated(true)
             runDir('runs/server')
+        }
+        datagen {
+            server()
+            setConfigName('Fabric Datagen')
+            ideConfigGenerated(true)
+            runDir('runs/datagen')
+            vmArg '-Dfabric-api.datagen'
+            vmArg "-Dfabric-api.datagen.output-dir=${project.file('src/generated/resources')}"
+            vmArg "-Dfabric-api.datagen.modid=${mod_id}"
         }
     }
 }

--- a/fabric/src/main/java/com/example/modtemplate/fabric/TemplateDatagen.java
+++ b/fabric/src/main/java/com/example/modtemplate/fabric/TemplateDatagen.java
@@ -1,0 +1,21 @@
+package com.example.modtemplate.fabric;
+
+import com.example.modtemplate.fabric.datagen.*;
+import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
+
+/**
+ * Datagen entry point for Fabric.
+ */
+public final class TemplateDatagen implements DataGeneratorEntrypoint {
+    @Override
+    public void onInitializeDataGenerator(FabricDataGenerator fabricDataGenerator) {
+        FabricDataGenerator.Pack pack = fabricDataGenerator.createPack();
+
+        pack.addProvider(ModBlockTagProvider::new);
+        pack.addProvider(ModItemTagProvider::new);
+        pack.addProvider(ModBlockLootTableProvider::new);
+        pack.addProvider(ModModelProvider::new);
+        pack.addProvider(ModRecipeProvider.Runner::new);
+    }
+}

--- a/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModBlockLootTableProvider.java
+++ b/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModBlockLootTableProvider.java
@@ -1,0 +1,21 @@
+package com.example.modtemplate.fabric.datagen;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
+import net.minecraft.core.HolderLookup;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generates block loot tables.
+ */
+public class ModBlockLootTableProvider extends FabricBlockLootTableProvider {
+    public ModBlockLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<HolderLookup.Provider> registryLookup) {
+        super(dataOutput, registryLookup);
+    }
+
+    @Override
+    public void generate() {
+        // Add loot table generation here
+    }
+}

--- a/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModBlockTagProvider.java
+++ b/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModBlockTagProvider.java
@@ -1,0 +1,21 @@
+package com.example.modtemplate.fabric.datagen;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.minecraft.core.HolderLookup;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generates block tags.
+ */
+public class ModBlockTagProvider extends FabricTagProvider.BlockTagProvider {
+    public ModBlockTagProvider(FabricDataOutput output, CompletableFuture<HolderLookup.Provider> registriesFuture) {
+        super(output, registriesFuture);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        // Add block tags here
+    }
+}

--- a/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModItemTagProvider.java
+++ b/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModItemTagProvider.java
@@ -1,0 +1,21 @@
+package com.example.modtemplate.fabric.datagen;
+
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricTagProvider;
+import net.minecraft.core.HolderLookup;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generates item tags.
+ */
+public class ModItemTagProvider extends FabricTagProvider.ItemTagProvider {
+    public ModItemTagProvider(FabricDataOutput output, CompletableFuture<HolderLookup.Provider> completableFuture) {
+        super(output, completableFuture);
+    }
+
+    @Override
+    protected void addTags(HolderLookup.Provider provider) {
+        // Add item tags here
+    }
+}

--- a/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModModelProvider.java
+++ b/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModModelProvider.java
@@ -1,0 +1,25 @@
+package com.example.modtemplate.fabric.datagen;
+
+import net.fabricmc.fabric.api.client.datagen.v1.provider.FabricModelProvider;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.minecraft.client.data.models.BlockModelGenerators;
+import net.minecraft.client.data.models.ItemModelGenerators;
+
+/**
+ * Generates models for blocks and items.
+ */
+public class ModModelProvider extends FabricModelProvider {
+    public ModModelProvider(FabricDataOutput output) {
+        super(output);
+    }
+
+    @Override
+    public void generateBlockStateModels(BlockModelGenerators blockModelGenerators) {
+        // Generate block models here
+    }
+
+    @Override
+    public void generateItemModels(ItemModelGenerators itemModelGenerators) {
+        // Generate item models here
+    }
+}

--- a/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModRecipeProvider.java
+++ b/fabric/src/main/java/com/example/modtemplate/fabric/datagen/ModRecipeProvider.java
@@ -1,0 +1,41 @@
+package com.example.modtemplate.fabric.datagen;
+
+import com.example.modtemplate.Constants;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.data.recipes.RecipeOutput;
+import net.minecraft.data.recipes.RecipeProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Generates crafting recipes.
+ */
+public class ModRecipeProvider extends RecipeProvider {
+    protected ModRecipeProvider(HolderLookup.Provider provider, RecipeOutput recipeOutput) {
+        super(provider, recipeOutput);
+    }
+
+    @Override
+    public void buildRecipes() {
+        // Add recipe generation here
+    }
+
+    public static class Runner extends FabricRecipeProvider {
+        public Runner(FabricDataOutput output, CompletableFuture<HolderLookup.Provider> registriesFuture) {
+            super(output, registriesFuture);
+        }
+
+        @Override
+        protected @NotNull RecipeProvider createRecipeProvider(HolderLookup.@NotNull Provider registries, @NotNull RecipeOutput output) {
+            return new ModRecipeProvider(registries, output);
+        }
+
+        @Override
+        public @NotNull String getName() {
+            return Constants.MOD_ID + " Recipes";
+        }
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,6 +17,9 @@
     "entrypoints": {
         "main": [
             "com.example.modtemplate.TemplateFabric"
+        ],
+        "fabric-datagen": [
+            "com.example.modtemplate.fabric.TemplateDatagen"
         ]
     },
     "mixins": [


### PR DESCRIPTION
## Summary
- add datagen entrypoint and providers for Fabric
- add datagen run configuration and generated resources directory
- register Fabric datagen entrypoint in `fabric.mod.json`

## Testing
- `./gradlew build --stacktrace` *(fails: NullPointerException in multiloader-common plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68640f3f5b308331b8e49d9187df1563